### PR TITLE
Support void

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,6 +239,7 @@ class QboConnector extends EventEmitter{
       if(e.update){
         options.update = function(payload, opts){
           var qs = {operation: 'update'};
+          if(opts.include === 'void') qs.include = 'void';
           if(opts.operation === 'void') qs.operation = 'void';
           if(opts && opts.reqid){
             qs.requestid=opts.reqid ;

--- a/index.js
+++ b/index.js
@@ -239,6 +239,7 @@ class QboConnector extends EventEmitter{
       if(e.update){
         options.update = function(payload, opts){
           var qs = {operation: 'update'};
+          if(opts.operation === 'void') qs.operation = 'void';
           if(opts && opts.reqid){
             qs.requestid=opts.reqid ;
           }


### PR DESCRIPTION
Currently the library does not support void.   The fix is easy by overriding the operation based on opts.   See Quickbook docs 

operation=void for invoices
https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#void-an-invoice

include=void for payment
https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/payment#void-a-payment